### PR TITLE
BYOP or Bring Your Own Proto

### DIFF
--- a/byop/README.md
+++ b/byop/README.md
@@ -1,0 +1,11 @@
+# BYOD
+
+**B**ring **Y**our **O**wn **P**roto :)
+
+# Why?
+
+Sometimes, bringing other modules into your repository might introduce a lot of dependencies which could break things in your own project or may not work with how your project is set up.
+Technically, you only care about the proto files used to communicate with the chain, and you can bring only them.
+
+Use the `byop` module to register them without bringing a lot of baggage that comes with the project you are trying to include.
+

--- a/byop/README.md
+++ b/byop/README.md
@@ -1,4 +1,4 @@
-# BYOD
+# BYOP
 
 **B**ring **Y**our **O**wn **P**roto :)
 

--- a/byop/module.go
+++ b/byop/module.go
@@ -29,15 +29,19 @@ func NewModule(moduleName string, msgs ...proto.Message) Module {
 	}
 }
 
-func (m Module) Name() string { return m.moduleName }
-
-// RegisterInterfaces is the only method that we care about.
+// RegisterInterfaces is the only method that we care about. It registers the
+// injected interfaces into the provided registry, so that it can be decoded.
 func (m Module) RegisterInterfaces(registry types.InterfaceRegistry) {
 	registry.RegisterImplementations(
 		(*sdk.Msg)(nil),
 		m.msgs...,
 	)
 }
+
+// All other methods below exist just to fulfill the module.AppModuleBasic interface.
+
+func (m Module) Name() string { return m.moduleName }
+
 func (m Module) RegisterLegacyAminoCodec(amino *codec.LegacyAmino) {}
 
 func (m Module) DefaultGenesis(codec.JSONCodec) json.RawMessage {

--- a/byop/module.go
+++ b/byop/module.go
@@ -2,7 +2,6 @@ package byop
 
 import (
 	"encoding/json"
-	"sync"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -18,17 +17,15 @@ import (
 var _ module.AppModuleBasic = Module{}
 
 type Module struct {
-	moduleName   string
-	registerOnce *sync.Once
+	moduleName string
 
 	msgs []proto.Message
 }
 
 func NewModule(moduleName string, msgs ...proto.Message) Module {
 	return Module{
-		moduleName:   moduleName,
-		registerOnce: &sync.Once{},
-		msgs:         msgs,
+		moduleName: moduleName,
+		msgs:       msgs,
 	}
 }
 
@@ -36,12 +33,10 @@ func (m Module) Name() string { return m.moduleName }
 
 // RegisterInterfaces is the only method that we care about.
 func (m Module) RegisterInterfaces(registry types.InterfaceRegistry) {
-	m.registerOnce.Do(func() {
-		registry.RegisterImplementations(
-			(*sdk.Msg)(nil),
-			m.msgs...,
-		)
-	})
+	registry.RegisterImplementations(
+		(*sdk.Msg)(nil),
+		m.msgs...,
+	)
 }
 func (m Module) RegisterLegacyAminoCodec(amino *codec.LegacyAmino) {}
 

--- a/byop/module.go
+++ b/byop/module.go
@@ -1,0 +1,62 @@
+package byop
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/gogo/protobuf/proto"
+	"github.com/gorilla/mux"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/spf13/cobra"
+)
+
+var _ module.AppModuleBasic = Module{}
+
+type Module struct {
+	moduleName   string
+	registerOnce *sync.Once
+
+	msgs []proto.Message
+}
+
+func NewModule(moduleName string, msgs ...proto.Message) Module {
+	return Module{
+		moduleName:   moduleName,
+		registerOnce: &sync.Once{},
+		msgs:         msgs,
+	}
+}
+
+func (m Module) Name() string { return m.moduleName }
+
+// RegisterInterfaces is the only method that we care about.
+func (m Module) RegisterInterfaces(registry types.InterfaceRegistry) {
+	m.registerOnce.Do(func() {
+		registry.RegisterImplementations(
+			(*sdk.Msg)(nil),
+			m.msgs...,
+		)
+	})
+}
+func (m Module) RegisterLegacyAminoCodec(amino *codec.LegacyAmino) {}
+
+func (m Module) DefaultGenesis(codec.JSONCodec) json.RawMessage {
+	panic("not required")
+}
+
+func (m Module) ValidateGenesis(codec.JSONCodec, client.TxEncodingConfig, json.RawMessage) error {
+	panic("not required")
+}
+
+func (m Module) RegisterRESTRoutes(client.Context, *mux.Router) { panic("not required") }
+
+func (m Module) RegisterGRPCGatewayRoutes(client.Context, *runtime.ServeMux) { panic("not required") }
+
+func (m Module) GetTxCmd() *cobra.Command { panic("not required") }
+
+func (m Module) GetQueryCmd() *cobra.Command { panic("not required") }


### PR DESCRIPTION
# Background

When I wanted to use a certain Cosmos SDK project's module and communicate with the chain via lens, I was unable to simply add the project into `go.mod` file and use their own proto files to communicate with their chain. Too many errors and too many _baggage dependencies.
Technically, the only thing that I need is the proto files which I can c/p from the project itself without bringing the whole project.


# Testing completed

- tested this to communicate with the third party chain
- TODO: write tests