### PR TITLE
Removing failing architectures from goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,11 +11,9 @@ builds:
       - -X github.com/strangelove-ventures/lens/cmd.Version={{ .Tag }}
       - -X github.com/strangelove-ventures/lens/cmd.Commit={{ .FullCommit }}
     goos:
-      - darwin
       - linux
     goarch:
       - amd64
-      - arm64
 
 checksum:
   name_template: SHA256SUMS-{{.Version}}.txt


### PR DESCRIPTION
There was a change introduced in November 2022 that is breaking builds for darwin_arm64, darwin_amd64, and linux_arm64.  Until this bug is fixed, we'll instruct goreleaser to just not build for these.